### PR TITLE
Fix a bug with calling Lua functions with arguments from Python

### DIFF
--- a/lua_sandbox/executor.py
+++ b/lua_sandbox/executor.py
@@ -550,7 +550,7 @@ class LuaValue(object):
         before_top = lua_gettop(self.L)
 
         try:
-            lua_args = map(lambda x: LuaValue.from_python(self, x), args)
+            lua_args = map(lambda x: LuaValue.from_python(self.executor, x), args)
         except Exception:
             # get ourselves off of the stack
             lua_pop(self.L, 1)

--- a/lua_sandbox/tests/tests.py
+++ b/lua_sandbox/tests/tests.py
@@ -213,6 +213,18 @@ class TestLuaExecution(unittest.TestCase):
         self.assertEqual(({1.0: 8.0, 2.0: 9.0},), ret)
         self.assertEqual([2.0, 3.0], closed)
 
+    def test_function_args(self):
+        program = """
+        local function multiplier(a, b)
+            return a*b
+        end
+        return multiplier
+        """
+        loaded = self.ex.lua.load(program)
+        func = loaded()[0]
+        multiplied = func(3, 7)
+        self.assertEqual([21.0], [x.to_python() for x in multiplied])
+
     def test_method_passing(self):
         class MyObject(object):
             def double(self, x):


### PR DESCRIPTION
We were calling LuaValue._from_python with the LuaValue instead if with
the Lua itself