### PR TITLE
lazy_capsule_index doesn't need the gil

### DIFF
--- a/lua_sandbox/executor.py
+++ b/lua_sandbox/executor.py
@@ -125,7 +125,7 @@ free_python_capsule = executor_lib.free_python_capsule
 free_python_capsule.restype = ctypes.c_int
 decapsule = executor_lib.decapsule
 decapsule.restype = ctypes.py_object
-lazy_capsule_index = executor_lib.lazy_capsule_index
+lazy_capsule_index = executor_lib_nogil.lazy_capsule_index
 lazy_capsule_index.restype = ctypes.c_int
 
 # function types


### PR DESCRIPTION
It manages the gil itself. Especially since it has the cache now, which may save having to get it at all