### PR TITLE
Add an interface to raw Lua strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ INSTALLEDENV=.env/installed
 installenv: ${INSTALLEDENV}
 
 check_dependencies:
-	which virtualenv-2.7
+	which virtualenv
 
 ${INSTALLEDENV}: setup.py
 	make check_dependencies
 	rm -fr .env
-	virtualenv-2.7 .env
+	virtualenv .env
 	make rebuild
 
 sdist: ${INSTALLEDENV}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # the basics required to get lua_sandbox compiling
-apt-get -y install python python-pip python-dev $USE_LUA_LIB
+apt-get -y install python python-pip python-dev python-virtualenv $USE_LUA_LIB
 
 # development conveniences
 apt-get -y install gdb python-all-dbg

--- a/c/_executormodule.c
+++ b/c/_executormodule.c
@@ -288,9 +288,10 @@ int call_python_function_from_lua(lua_State *L) {
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
-    PyObject* ret = PyObject_CallFunction(call_proxy, "OO",
+    PyObject* ret = PyObject_CallFunction(call_proxy, "OOi",
                                           executor,
-                                          capsule->val);
+                                          capsule->val,
+                                          capsule->raw_lua_args);
 
     if(ret == NULL) {
         // fixes the memory limiter and the GIL too
@@ -360,7 +361,8 @@ void store_python_capsule(lua_State *L,
                           PyObject* val,
                           long cycle_key,
                           int should_cache,
-                          int recursive) {
+                          int recursive,
+                          int raw_lua_args) {
     // our caller already added us to cycles so we don't have to worry about
     // it here
     lua_capsule* capsule =
@@ -374,6 +376,7 @@ void store_python_capsule(lua_State *L,
     capsule->cache_ref = LUA_REFNIL; // cache is populated lazily
     capsule->cache = should_cache;
     capsule->recursive = recursive;
+    capsule->raw_lua_args = raw_lua_args;
 }
 
 

--- a/c/_executormodule.h
+++ b/c/_executormodule.h
@@ -37,6 +37,7 @@ typedef struct {
     int cache_ref;
     int cache;
     int recursive;
+    int raw_lua_args;
 } lua_capsule;
 
 typedef struct {
@@ -59,7 +60,7 @@ size_t get_memory_used(lua_State *L);
 void enable_limit_memory(lua_State *L);
 void disable_limit_memory(lua_State *L);
 int call_python_function_from_lua(lua_State *L);
-void store_python_capsule(lua_State*,PyObject*,long,int,int);
+void store_python_capsule(lua_State*,PyObject*,long,int,int,int);
 int free_python_capsule(lua_State *L);
 PyObject* decapsule(lua_capsule* capsule);
 int lazy_capsule_index(lua_State*);


### PR DESCRIPTION
Normally when passing data back and forth between Pytho and Lua we just
copy it every time. But sometimes that can be really expensive,
particularly if it's the same data over and over. This adds an interface
to get zero-copy access to the Lua strings using the lua_tolstring
interface.

Python functions can't always deal with these buffer objects directly
and so this isn't necessarily always free. But it's useful for re.search
and co, who can deal with them just fine.