### PR TITLE
Performance improvements by using the registry less

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,25 @@ ${INSTALLEDENV}: setup.py
 	make check_dependencies
 	rm -fr .env
 	virtualenv .env
+	.env/bin/pip install setuptools --upgrade
 	make rebuild
 
 sdist: ${INSTALLEDENV}
 	.env/bin/python ./setup.py sdist
+
+bdist: ${INSTALLEDENV}
+	.env/bin/python ./setup.py bdist
 
 rebuild:
 	.env/bin/python ./setup.py develop
 	touch ${INSTALLEDENV}
 
 test: ${INSTALLEDENV}
-	.env/bin/python -m lua_sandbox.tests.tests ${TEST}
+	.env/bin/python ./setup.py test
 
 leaktest: ${INSTALLEDENV} test
-	LEAKTEST=true .env/bin/python -m lua_sandbox.tests.tests ${TEST} > /dev/null 2>&1
+	.env/bin/pip install pympler
+	LEAKTEST=true .env/bin/python -m lua_sandbox.tests.tests ${TEST} # > /dev/null 2>&1
 
 lldbtest: ${INSTALLEDENV}
 	lldb -f .env/bin/python -- -m lua_sandbox.tests.tests ${TEST}

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lldbtest: ${INSTALLEDENV}
 	lldb -f .env/bin/python -- -m lua_sandbox.tests.tests ${TEST}
 
 gdbtest: ${INSTALLEDENV}
-	gdb -ex=r --args .env/bin/python -m lua_sandbox.tests.tests ${TEST}
+	gdb -ex=r -ex=bt --args .env/bin/python -m lua_sandbox.tests.tests ${TEST}
 
 clean:
 	find lua_sandbox -type f -name \*.pyc -delete -print

--- a/c/_executormodule.c
+++ b/c/_executormodule.c
@@ -655,8 +655,8 @@ PyObject* lua_string_to_python_buffer(lua_State* L, int idx) {
     // make sense and (2) lua_tolstring will *convert* it into a string,
     // destructively
     size_t size = 0;
-    void* ptr = lua_tolstring(L, idx, &size);
-    PyObject* buff = PyBuffer_FromMemory(ptr, size); // new reference
+    const char* ptr = lua_tolstring(L, idx, &size);
+    PyObject* buff = PyBuffer_FromMemory((void*)ptr, size); // new reference
     // return that reference. it's up to our caller to free it, and to *not*
     // keep a reference to it after the string is no longer on the stack
     return buff;

--- a/lua_sandbox/executor.py
+++ b/lua_sandbox/executor.py
@@ -345,7 +345,7 @@ class Lua(object):
         # stack is [sv]
         lua_rawget(self.L, _executor.LUA_REGISTRYINDEX)
         # consumes sv leaving [registry]
-        return RegistryValue(self) # consumes [registry]
+        return RegistryValue(self) # consumes [registry] leaving []
 
     @check_stack(1, 0)
     def set_global(self, key, value):
@@ -354,7 +354,7 @@ class Lua(object):
 
         sv = StackValue.from_python(self, value)
         # stack is [value]
-        lua_setglobal(self.L, key) # consumes value leaving []
+        lua_setglobal(self.L, key) # consumes [value] leaving []
 
     def __setitem__(self, key, value):
         return self.set_global(key, value)
@@ -369,7 +369,7 @@ class Lua(object):
 
         lua_getglobal(self.L, key)
         # stack is [value]
-        return RegistryValue(self) # consumes [value]
+        return RegistryValue(self) # consumes [value] leaving []
 
     def __getitem__(self, key):
         return self.get_global(key)
@@ -392,7 +392,7 @@ class Lua(object):
 
         if load_ret == _executor.LUA_OK:
             # stack is [code]
-            return RegistryValue(self)  # consumes code
+            return RegistryValue(self)  # consumes code leaving []
         elif load_ret == _executor.LUA_ERRSYNTAX:
             raise LuaSyntaxError(self)
         elif load_ret == _executor.LUA_ERRMEM:

--- a/lua_sandbox/executor.py
+++ b/lua_sandbox/executor.py
@@ -993,7 +993,7 @@ class RegistryValue(_LuaValue):
         with self._bring_to_top() as sv:
             return sv.getitem(key).as_ref()
 
-    # @check_stack(1, 0) TODO
+    @check_stack(1, 0)
     def __call__(self, *args):
         # print 1, lua_gettop(self.L)
         with self._bring_to_top() as sv:

--- a/lua_sandbox/executor.py
+++ b/lua_sandbox/executor.py
@@ -154,10 +154,6 @@ def lua_isnil(L, idx):
     return lua_type(L, idx) == _executor.LUA_TNIL
 
 
-def luaL_typename(L, idx):
-    return lua_typename(L, lua_type(L, idx))
-
-
 if _executor.LUA_VERSION_NUM == 501:
     lua_pcallk = executor_lib_nogil.memory_safe_pcallk
 

--- a/lua_sandbox/executor.py
+++ b/lua_sandbox/executor.py
@@ -598,18 +598,12 @@ class StackValue(_LuaValue):
         # craziness. Because of this, the actual call site is in
         # _executormodule.c who can better deal with that stuff
 
-        # print 'bt-2', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
-
         self._bring_to_top(False)  # lua_pcallk consumes
-
-        # smking gun? it's not on top after this?
-        # print 'bt-1', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
 
         if not lua_checkstack(self.L, 2+len(args)):
             raise LuaOutOfMemoryException("__call__.checkstack")
 
         before_top = lua_gettop(self.L)
-        # print 'bt', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
 
         lua_args = []
 
@@ -624,8 +618,6 @@ class StackValue(_LuaValue):
             else:
                 lua_args.append(sv)
 
-        # print 'bt2', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
-
         # allocation limiting must only be turned on while we're operating
         # inside of a pcall, or Lua's crazy longjmp thing will kick in
         enable_limit_memory(self.L)
@@ -636,14 +628,10 @@ class StackValue(_LuaValue):
                                len(lua_args), _executor.LUA_MULTRET,
                                0, 0, None)
 
-        # print 'at0', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
-
         disable_limit_memory(self.L)
 
         if pcall_ret == _executor.LUA_OK:
             after_top = lua_gettop(self.L)
-            # print 'at1', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
-
             rets = []
 
             # consumes them from the stack as we go
@@ -652,8 +640,6 @@ class StackValue(_LuaValue):
                 # easy be StackValues to be translated in
                 # RegistryValue.__call__ like we do other things
                 rets.append(RegistryValue(self.executor))
-
-            # print 'at2', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
 
             rets.reverse()
 
@@ -947,9 +933,7 @@ class RegistryValue(_LuaValue):
             raise LuaOutOfMemoryException("_bring_to_top.checkstack")
 
         # get the value to the top of the stack
-        # print 'X1', self.key, lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
         lua_rawgeti(self.L, _executor.LUA_REGISTRYINDEX, self.key)
-        # print 'X2', lua_gettop(self.L), lua_gettop(self.L) and luaL_typename(self.L, -1)
 
         if cleanup_after:
             return self.__bring_to_top_cleanup()

--- a/lua_sandbox/executor.py
+++ b/lua_sandbox/executor.py
@@ -979,13 +979,9 @@ class RegistryValue(_LuaValue):
 
     @check_stack(1, 0)
     def __call__(self, *args):
-        # print 1, lua_gettop(self.L)
         with self._bring_to_top() as sv:
-            # print 2, lua_gettop(self.L)
             # he returns RegistryValues for our convenience here
             ret = sv(*args)
-            # print 3, lua_gettop(self.L)
-        # print 4, lua_gettop(self.L)
         return ret
 
     @classmethod
@@ -1125,7 +1121,6 @@ class SandboxedExecutor(object):
         loaded_sandboxer = self.ex.load(
             sandboxer,
             desc='%s.sandboxer' % self.ex.name)
-        # print '*'*20, loaded_sandboxer
         sandboxer_result = loaded_sandboxer()
         self.sandbox = sandboxer_result[0]
 

--- a/lua_sandbox/tests/tests.py
+++ b/lua_sandbox/tests/tests.py
@@ -376,7 +376,7 @@ class TestLuaExecution(unittest.TestCase):
         self.assertEqual(self.ex.lua['x'].to_python(), 5.0)
 
         # nils
-        self.assertEqual(self.ex.lua['bar'].type_name(), 'nil')
+        self.assertEqual(self.ex.lua['bar'].lua_type_name(), 'nil')
         self.assertEqual(self.ex.lua['bar'].to_python(), None)
 
         # loaded code can get to it
@@ -388,7 +388,7 @@ class TestLuaExecution(unittest.TestCase):
         t = self.ex.lua.create_table()
         t['foo'] = 5
         self.assertEquals(t['foo'].to_python(), 5.0)
-        self.assertEquals(t['bar'].type_name(), 'nil')
+        self.assertEquals(t['bar'].lua_type_name(), 'nil')
         self.assertEquals(t['bar'].to_python(), None)
         self.assertTrue(t['bar'].is_nil())
 
@@ -534,7 +534,7 @@ if __name__ == '__main__':
         tr = tracker.SummaryTracker()
 
         def _fn():
-            for _ in range(10):
+            for _ in xrange(10000):
                 unittest.main(verbosity=0, exit=False)
 
         while True:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if 'jit' in LUA_LIB_NAME:
 
 setup(
     name=PACKAGE_NAME,
-    version='2.1.8',
+    version='2.2.0',
     description='A library to run lua code inside of a sandbox from Python',
     author='David King',
     author_email='dking@ketralnis.com',
@@ -56,7 +56,7 @@ setup(
     package_data={'lua_sandbox': ['lua_sandbox/lua_utils/*.lua']},
     zip_safe=False,
     include_package_data=True,
-    install_requires=[
-        "mock==2.0.0",
-    ],
+    install_requires=['mock', 'nose'],
+    tests_require=['mock', 'nose',],
+    test_suite="nose.collector",
 )

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        ""
+        "mock==1.0.0",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        "mock==1.0.0",
+        "mock==2.0.0",
     ],
 )


### PR DESCRIPTION
Using the Lua C library, it's not possible to hold a Lua value in a
variable (and by extension for us a Python variable). Instead all Lua
values are stored on the Lua stack, and you can keep track of them via
the integer on the stack. That works okay for small self-contained
functions that take and return values, but then how do you keep
long-lived references to compiled functions, or return values back to
Python where they may outlive the function that created them or be
stored in containers?

The answer is that Lua also has another global place to store things
called the Registry. It has a call `luaL_ref` which allocates and
returns an index into the registry and promises that the registry counts
as a reference to the value so it won't be GC'd

So every time lua_sandbox needs to talk about a Lua value it wraps it in
a Python object called a `LuaValue` which maintains the registry index
and manages moving the Lua value in and out of it. That works, but it
means that we have a surprising number of calls into Lua to do really
basic operations. In particular `LuaValue.__setitem__`, called when
setting sandbox globals like `lua.sandbox['thing'] = Something()`,
accounts for a lot of time in my own use case for lua_sandbox.
`LuaValue.__setitem__` does a lot of stuff including serialising
from Python to Lua and actually updating the Lua table, but some
fraction of that time is spent just moving stuff in and out of the
registry. Not a lot, but enough to show up in profiling.

This patch tries to cut that down a bit by cutting out some of the
registry management down. It does that by splitting LuaValue into
StackValue (which now represents a Lua value on the stack) and
RegistryValue (which does what LuaValue was doing before with all of the
registry management). To keep the external API stable we only use
StackValue internally and continue to use RegistryValue everywhere that
we leak references into our callers so it's still safe for them to keep
the references that we give them