### PR TITLE
as_buffer returns a real buffer object

### DIFF
--- a/c/_executormodule.c
+++ b/c/_executormodule.c
@@ -610,6 +610,20 @@ static void create_capsule_cache(lua_State* L, lua_capsule* capsule) {
 }
 
 
+PyObject* lua_string_to_python_buffer(lua_State* L, int idx) {
+    // our caller already checked that it's a string.  we insist that it's
+    // actually a string because (1) otherwise wanting a buffer into it doesn't
+    // make sense and (2) lua_tolstring will *convert* it into a string,
+    // destructively
+    size_t size = 0;
+    void* ptr = lua_tolstring(L, idx, &size);
+    PyObject* buff = PyBuffer_FromMemory(ptr, size); // new reference
+    // return that reference. it's up to our caller to free it, and to *not*
+    // keep a reference to it after the string is no longer on the stack
+    return buff;
+}
+
+
 static int add_int_constant(PyObject* module, char* name, int value) {
     PyObject *as_int = PyInt_FromLong(value);
     if(as_int == NULL) {

--- a/c/_executormodule.h
+++ b/c/_executormodule.h
@@ -64,6 +64,7 @@ void store_python_capsule(lua_State*,PyObject*,long,int,int,int);
 int free_python_capsule(lua_State *L);
 PyObject* decapsule(lua_capsule* capsule);
 int lazy_capsule_index(lua_State*);
+PyObject* lua_string_to_python_buffer(lua_State*, int idx);
 static int check_capsule_cache(lua_State* L, lua_capsule*, int);
 static void set_capsule_cache(lua_State* L, lua_capsule*, int, int);
 static void create_capsule_cache(lua_State* L, lua_capsule*);

--- a/lua_sandbox/tests/tests.py
+++ b/lua_sandbox/tests/tests.py
@@ -347,11 +347,13 @@ class TestLuaExecution(unittest.TestCase):
     def test_buffer_interface(self):
         # we can get a buffer into a Lua string and, and re.search works on
         # that buffer
-        loaded = self.ex.lua.load(""" return "this is my string" """)
+        s = b""" return "this is my string" """
+        loaded = self.ex.lua.load(s)
         lua_string, = loaded()
         with lua_string.as_buffer() as buff:
-            self.assertEqual(re.search('my (string)', buff).groups(),
+            self.assertEqual(re.search('my (string.*)', buff).groups(),
                              ('string',))
+            self.assertEqual(len(buff), len('this is my string'))
 
         # this is the regular callback way with lots of copies, here mostly for
         # demonstration


### PR DESCRIPTION
LuaValues that are backed by strings have an `as_buffer` contextmanager
that yields a buffer into the memory backing the string. This is useful
to keep from having to pass large strings back and forth, for use cases
that support the buffer interface (which notably includes `re`).

Before this patch, we used the fact that ctypes pointer types
implemented the buffer protocol, even though they weren't buffer objects
specifically.

Some libraries (notably `re2`) however need actual vanilla buffer
objects. This converts us over to using vanilla buffer objects so we can
still avoid the copying while using those libraries